### PR TITLE
add blur helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepertax/react-otp-input",
-  "version": "2.4.3",
+  "version": "2.4.4-alpha.1",
   "description": "A fully customizable, one-time password input component for the web built with React",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepertax/react-otp-input",
-  "version": "2.4.4-alpha.1",
+  "version": "2.4.4",
   "description": "A fully customizable, one-time password input component for the web built with React",
   "main": "lib/index.js",
   "scripts": {

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -26,6 +26,10 @@ class Demo extends Component {
 
   handleOtpChange = (otp) => {
     this.setState({ otp });
+
+    if (otp.length === 4) {
+      this.otpRef.current.blurInput();
+    }
   };
 
   handleChange = (e) => {
@@ -47,10 +51,6 @@ class Demo extends Component {
 
   clearOtp = () => {
     this.setState({ otp: '' });
-  };
-
-  blurOtp = () => {
-    this.otpRef.blurInput();
   };
 
   handleCheck = (e) => {
@@ -200,9 +200,6 @@ class Demo extends Component {
                   onClick={this.clearOtp}
                 >
                   Clear
-                </button>
-                <button className="btn margin-top--large" type="button" onClick={this.blurOtp}>
-                  Blur
                 </button>
                 <button className="btn margin-top--large" disabled={otp.length < numInputs}>
                   Get OTP

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -20,6 +20,8 @@ class Demo extends Component {
       maxLength: 40,
       placeholder: '',
     };
+
+    this.otpRef = React.createRef();
   }
 
   handleOtpChange = (otp) => {
@@ -45,6 +47,10 @@ class Demo extends Component {
 
   clearOtp = () => {
     this.setState({ otp: '' });
+  };
+
+  blurOtp = () => {
+    this.otpRef.blurInput();
   };
 
   handleCheck = (e) => {
@@ -144,6 +150,7 @@ class Demo extends Component {
                 type="checkbox"
                 checked={isInputNum}
                 onChange={this.handleCheck}
+                f
               />
               isInputNum
             </label>
@@ -170,6 +177,7 @@ class Demo extends Component {
               <p>Enter verification code</p>
               <div className="margin-top--small">
                 <OtpInput
+                  ref={this.otpRef}
                   inputStyle="inputStyle"
                   numInputs={numInputs}
                   isDisabled={isDisabled}
@@ -192,6 +200,9 @@ class Demo extends Component {
                   onClick={this.clearOtp}
                 >
                   Clear
+                </button>
+                <button className="btn margin-top--large" type="button" onClick={this.blurOtp}>
+                  Blur
                 </button>
                 <button className="btn margin-top--large" disabled={otp.length < numInputs}>
                   Get OTP

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -58,6 +58,10 @@ class SingleOtpInput extends PureComponent {
     return 'text';
   };
 
+  blur = () => {
+    this.input.current.blur();
+  };
+
   render() {
     const {
       placeholder,

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -127,6 +127,8 @@ class OtpInput extends Component {
     activeInput: 0,
   };
 
+  inputRef = React.createRef();
+
   getOtpValue = () => (this.props.value ? this.props.value.toString().split('') : []);
 
   getPlaceholderValue = () => {
@@ -181,6 +183,12 @@ class OtpInput extends Component {
   focusPrevInput = () => {
     const { activeInput } = this.state;
     this.focusInput(activeInput - 1);
+  };
+
+  blurInput = () => {
+    if (this.inputRef.current) {
+      this.inputRef.current.blur();
+    }
   };
 
   // Change OTP value at focused input
@@ -314,6 +322,7 @@ class OtpInput extends Component {
           key={i}
           index={i}
           focus={activeInput === i}
+          ref={activeInput === i ? this.inputRef : null}
           value={otp && otp[i]}
           onChange={this.handleOnChange}
           onKeyDown={this.handleOnKeyDown}


### PR DESCRIPTION
Add ability to blur otp input

This is needed for mobile. When the user enters an incorrect code on ios, if the keyboard is popped up, the snackbar is hidden. so we add the ability to blur (which will hide the keyboard) so we can make sure the snackbar is visible.

Example added to the demo code:

This shows what happens when the blur helper is called.

<img width="452" alt="Screen Shot 2022-02-03 at 4 02 02 PM" src="https://user-images.githubusercontent.com/52947917/152449769-db6023de-5b30-4124-8866-93d710959924.png">
<img width="450" alt="Screen Shot 2022-02-03 at 4 02 06 PM" src="https://user-images.githubusercontent.com/52947917/152449770-f2d30c46-9702-4040-81b7-b6f8a0a8e08c.png">

